### PR TITLE
fix: Continue restoring service layer files

### DIFF
--- a/src/services/driver/Driver.types.ts
+++ b/src/services/driver/Driver.types.ts
@@ -1,0 +1,19 @@
+// src/services/driver/Driver.types.ts
+export interface DriverDto {
+  id: string;
+  name: string;
+  // Add any other properties if specified by API response (Swagger schema is open)
+  [key: string]: unknown; // Changed 'any' to 'unknown'
+}
+
+export type ListDriversResponseDto = DriverDto[];
+
+export interface GetDriversQueryParams {
+  limit?: number;
+  offset?: number;
+  withTrashed?: 0 | 1;
+  orderBy?: string;
+  sort?: 'ASC' | 'DESC';
+  id?: string;
+  name?: string;
+}

--- a/src/services/driver/DriverService.ts
+++ b/src/services/driver/DriverService.ts
@@ -1,0 +1,12 @@
+// src/services/driver/DriverService.ts
+import apiClient from '../apiClient';
+import { GetDriversQueryParams, ListDriversResponseDto } from './Driver.types';
+
+const DRIVER_BASE_URL = '/driver';
+
+export const DriverService = {
+  listDrivers: async (params?: GetDriversQueryParams): Promise<ListDriversResponseDto> => {
+    const response = await apiClient.get<ListDriversResponseDto>(DRIVER_BASE_URL, { params });
+    return response.data;
+  },
+};


### PR DESCRIPTION
This commit continues the effort to restore critical service layer code that was found to be missing due to a branch misalignment.

Restored Services in this commit:
- Group Service: Re-created all files in `src/services/group/` (types, service, converters).
- Place Service: Re-created all files in `src/services/place/`.
- Map Service: Re-created all files in `src/services/map/`.
- ConnectionType Service: Re-created `ConnectionType.types.ts` and `ConnectionTypeService.ts` in `src/services/connectiontype/`.
- DeviceType Service: Re-created `DeviceType.types.ts` and `DeviceTypeService.ts` in `src/services/devicetype/`.
- DeviceVendor Service: Re-created all files in `src/services/devicevendor/`.
- DeviceModel Service: Re-created all files in `src/services/devicemodel/`.
- Driver Service: Re-created `Driver.types.ts` and `DriverService.ts` in `src/services/driver/`.

This is part of Phase 1 of the recovery plan. More services (DeviceFirmware, Device, DeviceMonitoring, DeviceStatus, EventType, Shift, Event, File) remain to be restored before proceeding to Redux integration for all services.